### PR TITLE
Use new pattern to macth @token-like-this@

### DIFF
--- a/loadConfig.xml
+++ b/loadConfig.xml
@@ -3,7 +3,7 @@
         <loadfile property="file.config" file="${absfilename}">
             <filterchain>
                 <replaceregexp>
-                    <regexp pattern="@(([a-z]*\.*)*)@" replace="${\1}"/>
+                    <regexp pattern="@(.[^@]*)@" replace="${\1}"/>
                 </replaceregexp>
             </filterchain>
         </loadfile>


### PR DESCRIPTION
Changelog: 

In project Symbiose-api we used phing param with '-' character : https://github.com/flash-global/symbiose-api/blob/master/app/config/params.local.php.dist . So replace the pattern @(([a-z]*\.*)*)@ by @(.[^@]*)@ to match with.