### PR TITLE
Updated repository distant url : now just update webhook & tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "https://composer.flash-global.net"
+      "url": "https://composer.flash.global"
     }
   ]
 }


### PR DESCRIPTION
`https://composer.flash-global.net/` does not have ssl anymore
Updating to `https://composer.flash.global`