### PR TITLE
Add objective 2 config handling (json)

### DIFF
--- a/loadConfig.xml
+++ b/loadConfig.xml
@@ -15,6 +15,7 @@
         <foreach param="filename" absparam="absfilename" target="sub-setup-config">
             <fileset dir="${config.path}/local">
                 <include name="*.php.dist" />
+                <include name="*.json.dist" />
             </fileset>
         </foreach>
         <foreach param="filename" absparam="absfilename" target="clean-name-dist">


### PR DESCRIPTION
In Objective 2, config file changed from PHP files to JSON.

This PR was made to make phing-package objective2 compatible : we just add the handling of json files in xml configuration.