### PR TITLE
Implement overriding property file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ qaBeanstalk=[CONTAINER BEANSTALK NAME] (if needed)
 ```
 > NB : After tag 3.* you have to prefix [CONFIG PATH] with ${project.basedir}
 
+Override `settings_local.ini` :
+For local usage it can be useful to override default local settings with specifics.
+To do this you just have to create file named `settings_local.override.ini` which will :
+- redefine properties
+- define new properties
+
+This file must be ignored.
+
 Complete this script with your properties with following pattern :
 ```ini
 [NAME OF CONFIG FILE].[YOUR OWN KEY]

--- a/loadProperties.xml
+++ b/loadProperties.xml
@@ -1,6 +1,14 @@
 <project name="project" default="help" basedir=".">
     <target name="load-properties" description="Load properties file">
-        <available file='${project.basedir}/settings_local.ini' type='file' property="buildProperties.Exists" />
+        <available file='${project.basedir}/settings_local.override.ini' type='file' property="buildProperties.Exists"/>
+        <if>
+            <isset property="buildProperties.Exists"/>
+            <then>
+                <property file="${project.basedir}/settings_local.override.ini"/>
+            </then>
+        </if>
+
+        <available file='${project.basedir}/settings_local.ini' type='file' property="buildProperties.Exists"/>
         <if>
             <isset property="buildProperties.Exists"/>
             <then>

--- a/loadProperties.xml
+++ b/loadProperties.xml
@@ -1,8 +1,8 @@
 <project name="project" default="help" basedir=".">
     <target name="load-properties" description="Load properties file">
-        <available file='${project.basedir}/settings_local.override.ini' type='file' property="buildProperties.Exists"/>
+        <available file='${project.basedir}/settings_local.override.ini' type='file' property="overrideProperties.Exists"/>
         <if>
-            <isset property="buildProperties.Exists"/>
+            <isset property="overrideProperties.Exists"/>
             <then>
                 <property file="${project.basedir}/settings_local.override.ini"/>
             </then>


### PR DESCRIPTION
Load properties target as been improved to allow overriding file usage
by creating a file named `setting_local.override.ini`.
This overriding allow :
- redeclaring exisiting propertie(s)
- declare new propertie(s)

NB: The overriding property loading is written before normal property
loading in phing xml logic. Maybe this mean an existing property cannot
be written ? Whatever it's working.